### PR TITLE
FEAT: Add Login and Signup Screens

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,23 @@
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 import { Navbar } from "./components";
-import { Home } from "./screens";
+import { Home, Login, Signup } from "./screens";
 import "./App.css";
 
 const App = () => {
+  const { pathname } = useLocation();
+
   return (
-    <div className="App scroll-smooth text-gray-800">
-      <Navbar />
-      <main className="bg-slate-100 h-full min-h-screen py-16 px-3">
+    <div className="App box-border scroll-smooth text-gray-800">
+      {pathname !== "/login" && pathname !== "/signup" ? <Navbar /> : <></>}
+      <main
+        className={`bg-slate-100 h-full min-h-screen ${
+          pathname !== "/login" && pathname !== "/signup" ? "py-16 px-3" : ""
+        }`}
+      >
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
         </Routes>
       </main>
     </div>

--- a/src/components/SignupStepOne.jsx
+++ b/src/components/SignupStepOne.jsx
@@ -1,0 +1,47 @@
+import { User, Lock, Eye } from "../icons";
+
+const SignupStepOne = () => {
+  return (
+    <>
+      <h5 className="text-2xl font-bold text-center mb-3">
+        Tell us more about you
+      </h5>
+      <div className="bg-white border border-slate-200 rounded-xl p-6">
+        <div className="flex flex-col gap-4">
+          <div className="p-2 rounded-lg bg-slate-50 border border-slate-200">
+            <label className="w-full px-2 bg-slate-50 text-slate-400 text-xs uppercase">
+              First Name
+            </label>
+            <input
+              className="w-full p-2 bg-slate-50"
+              type="text"
+              placeholder="Bablu"
+            />
+          </div>
+          <div className="p-2 rounded-lg bg-slate-50 border border-slate-200">
+            <label className="w-full px-2 bg-slate-50 text-slate-400 text-xs uppercase">
+              Last Name
+            </label>
+            <input
+              className="w-full p-2 bg-slate-50"
+              type="text"
+              placeholder="Tailor"
+            />
+          </div>
+          <div className="p-2 rounded-lg bg-slate-50 border border-slate-200">
+            <label className="w-full px-2 bg-slate-50 text-slate-400 text-xs uppercase">
+              Email
+            </label>
+            <input
+              className="w-full p-2 bg-slate-50"
+              type="email"
+              placeholder="bablu@gmail.com"
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export { SignupStepOne };

--- a/src/components/SignupStepThree.jsx
+++ b/src/components/SignupStepThree.jsx
@@ -1,0 +1,26 @@
+import { ASSETS_URL } from "../constants";
+
+const SignupStepThree = () => {
+  return (
+    <>
+      <h5 className="text-2xl font-bold text-center mb-3">
+        You're all set. Ready?
+      </h5>
+      <div className="flex flex-col gap-4 items-center bg-white border border-slate-200 rounded-xl p-6">
+        <img
+          src={`${ASSETS_URL}/v1649850755/REcom/mailbox_aj5s4t.svg`}
+          className="w-32 h-32"
+          alt="mailbox"
+        />
+        <h6 className="font-bold text-center">
+          Congratz, you successfully created your account.
+        </h6>
+        <button className="w-fit px-6 py-2 bg-blue-400 text-white rounded-lg">
+          Let Me In
+        </button>
+      </div>
+    </>
+  );
+};
+
+export { SignupStepThree };

--- a/src/components/SignupStepTwo.jsx
+++ b/src/components/SignupStepTwo.jsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Eye, EyeOff } from "../icons";
+
+const SignupStepTwo = () => {
+  const [passwordVisible, setPasswordVisible] = useState(false);
+
+  return (
+    <>
+      <h5 className="text-2xl font-bold text-center mb-3">
+        Secure your account
+      </h5>
+      <div className="bg-white border border-slate-200 rounded-xl p-6">
+        <div className="flex flex-col gap-4">
+          <div className="p-2 rounded-lg bg-slate-50 border border-slate-200 relative">
+            <label className="w-full px-2 bg-slate-50 text-slate-400 text-xs uppercase">
+              Password
+            </label>
+            <input
+              className="w-full p-2 bg-slate-50"
+              type={passwordVisible ? "text" : "password"}
+              placeholder="••••••••"
+            />
+            <button
+              className="absolute top-1/2 transform -translate-y-1/2 right-4 text-xl text-slate-300 cursor-pointer transition-colors duration-200 hover:text-gray-800"
+              onClick={() => setPasswordVisible((prevState) => !prevState)}
+            >
+              {passwordVisible ? <EyeOff /> : <Eye />}
+            </button>
+          </div>
+          <div className="p-2 rounded-lg bg-slate-50 border border-slate-200">
+            <label className="w-full px-2 bg-slate-50 text-slate-400 text-xs uppercase">
+              Confirm Password
+            </label>
+            <input
+              className="w-full p-2 bg-slate-50"
+              type="password"
+              placeholder="••••••••"
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export { SignupStepTwo };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,4 +4,7 @@ export { FeedScroll } from "./FeedScroll";
 export { Navbar } from "./Navbar";
 export { PostCard } from "./PostCard";
 export { ProfileDescCard } from "./ProfileDescCard";
+export { SignupStepOne } from "./SignupStepOne";
+export { SignupStepThree } from "./SignupStepThree";
+export { SignupStepTwo } from "./SignupStepTwo";
 export { SuggestedFriends } from "./SuggestedFriends";

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -2,6 +2,8 @@ import { BiEnvelope } from "react-icons/bi";
 import { GrStackOverflow } from "react-icons/gr";
 import { AiOutlineAppstore } from "react-icons/ai";
 import {
+  FaEye,
+  FaEyeSlash,
   FaFacebookF,
   FaGithub,
   FaHeart,
@@ -20,6 +22,7 @@ import {
   FiEdit3,
   FiImage,
   FiLink2,
+  FiLock,
   FiMenu,
   FiMessageCircle,
   FiMessageSquare,
@@ -40,6 +43,8 @@ export {
   /****** UTILITY ******/
   AiOutlineAppstore as Apps,
   BiEnvelope as Message,
+  FaEye as Eye,
+  FaEyeSlash as EyeOff,
   FaHouseUser as House,
   FaLaptopCode as Laptop,
   FaRegHeart as Like,
@@ -49,6 +54,7 @@ export {
   FiEdit3 as Pencil,
   FiImage as Image,
   FiLink2 as Link,
+  FiLock as Lock,
   FiMenu as Menu,
   FiMessageCircle as Comment,
   FiMessageSquare as Chat,
@@ -64,10 +70,10 @@ export {
   FiUserX as RemoveFriend,
   FiX as Close,
   GrStackOverflow as Stack,
-  
+
   /****** SOLID ******/
   FaHeart as Liked,
-
+  
   /****** BRANDS ******/
   FaFacebookF as Facebook,
   FaGithub as Github,

--- a/src/index.css
+++ b/src/index.css
@@ -3,17 +3,26 @@
 @tailwind utilities;
 
 @layer components {
+  #root {
+    min-height: 100vh;
+    height: 100%;
+    width: 100%;
+  }
+
+  body {
+    min-height: 100vh;
+    height: 100%;
+    width: 100%;
+    scrollbar-color: #60a5fa #f1f5f9;
+    scrollbar-width: thin;
+  }
+
   ::-webkit-scrollbar {
     width: 6px;
   }
 
   ::-webkit-scrollbar-track {
     background-color: #f1f5f9;
-  }
-
-  body {
-    scrollbar-color: #60a5fa #f1f5f9;
-    scrollbar-width: thin;
   }
 
   .textarea {
@@ -27,7 +36,17 @@
     outline: none;
   }
 
-  .textarea::placeholder {
+  .textarea::placeholder,
+  input::placeholder {
     color: #c7c7c7;
+    font-weight: 100;
+  }
+
+  input:focus {
+    outline: none;
+  }
+
+  main .loginSection {
+    height: 100vh;
   }
 }

--- a/src/screens/Login.jsx
+++ b/src/screens/Login.jsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { User, Lock, Eye, EyeOff } from "../icons";
+import { ASSETS_URL } from "../constants";
+
+const Login = () => {
+  const [passwordVisible, setPasswordVisible] = useState(false);
+
+  return (
+    <section className="flex items-center justify-center h-full w-full m-auto loginSection">
+      <div className="relative h-full w-full hidden bg-blue-400 md:flex md:justify-center md:items-center">
+        <img
+          src={`${ASSETS_URL}/v1649485162/REcom/logo_oahebo.png`}
+          className="h-20 w-20 border-4 border-slate-100 rounded-full absolute -right-10"
+          alt="logo"
+        />
+      </div>
+      <div className="flex flex-col items-center justify-center h-full w-full m-auto">
+        <div className="w-full max-w-xs">
+          <div className="flex flex-col gap-2">
+            <div className="relative">
+              <input
+                className="w-full py-2 px-4 pl-9 rounded-lg bg-white border-slate-200 border focus:border-blue-500"
+                type="email"
+                placeholder="bablu@gmail.com"
+              />
+              <User className="absolute top-1/2 transform -translate-y-1/2 left-2 text-xl text-slate-300" />
+            </div>
+            <div className="relative">
+              <input
+                className="w-full py-2 px-4 pl-9 rounded-lg bg-white border-slate-200 border focus:border-blue-500"
+                type={passwordVisible ? "text" : "password"}
+                placeholder="Password"
+              />
+              <Lock className="absolute top-1/2 transform -translate-y-1/2 left-2 text-xl text-slate-300" />
+              <button
+                className="absolute top-1/2 transform -translate-y-1/2 right-4 text-xl text-slate-300 cursor-pointer transition-colors duration-200 hover:text-gray-800"
+                onClick={() => setPasswordVisible((prevState) => !prevState)}
+              >
+                {passwordVisible ? <EyeOff /> : <Eye />}
+              </button>
+            </div>
+          </div>
+          <div className="flex justify-between w-full mt-2">
+            <div className="flex gap-1 text-xs">
+              <p>Not a user?</p>
+              <Link to="/signup" className="underline">
+                Sign-up
+              </Link>
+            </div>
+            <button className="text-xs underline">Forgot Password?</button>
+          </div>
+          <button className="w-full px-6 py-2 bg-blue-400 text-white rounded-full mt-6">
+            Login
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export { Login };

--- a/src/screens/Signup.jsx
+++ b/src/screens/Signup.jsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { ASSETS_URL } from "../constants";
+import { SignupStepOne, SignupStepThree, SignupStepTwo } from "../components";
+
+const Signup = () => {
+  const [step, setStep] = useState(1);
+
+  return (
+    <section className="flex flex-col items-center justify-center h-full w-full m-auto loginSection">
+      <div className="h-fit w-full bg-blue-400 flex flex-col justify-center items-center">
+        <p className="my-2 text-white text-2xl uppercase">Join RECom</p>
+        <img
+          src={`${ASSETS_URL}/v1649485162/REcom/logo_oahebo.png`}
+          className="h-20 w-20 border-4 border-slate-100 rounded-full -mb-10"
+          alt="logo"
+        />
+      </div>
+      <div className="flex flex-col items-center h-full w-full max-w-md m-auto mt-20 px-4">
+        <article className="w-full">
+          {(() => {
+            switch (step) {
+              case 1:
+                return <SignupStepOne />;
+              case 2:
+                return <SignupStepTwo />;
+              case 3:
+                return <SignupStepThree />;
+              default:
+                return <></>;
+            }
+          })()}
+        </article>
+        {step < 3 ? (
+          <div className="w-full flex gap-2 justify-between mt-4">
+            <div className="flex justify-between w-full mt-2">
+              <div className="flex gap-1 text-xs">
+                <p className="text-lg">Already a user?</p>
+                <Link to="/login" className="underline text-lg">
+                  Login
+                </Link>
+              </div>
+            </div>
+            {step > 1 ? (
+              <button
+                className="w-fit px-6 py-2 border border-slate-200 bg-white text-gray-800 rounded-xl transition-colors duration-200  hover:border-blue-400 hover:shadow hover:shadow-slate-300"
+                onClick={() => setStep((prevStep) => prevStep - 1)}
+              >
+                Back
+              </button>
+            ) : (
+              <></>
+            )}
+            {step < 3 ? (
+              <button
+                className="w-fit px-6 py-2 border border-slate-200 bg-white text-gray-800 rounded-xl transition-colors duration-200 hover:bg-blue-400 hover:text-white hover:border-blue-400 hover:shadow hover:shadow-blue-300"
+                onClick={() => setStep((prevStep) => prevStep + 1)}
+              >
+                Next
+              </button>
+            ) : (
+              <></>
+            )}
+          </div>
+        ) : (
+          <></>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export { Signup };

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,1 +1,3 @@
 export { Home } from "./Home";
+export { Login } from "./Login";
+export { Signup } from "./Signup";


### PR DESCRIPTION
### 📝 Description

Login and Signup screens are for the users to login or signup if they're not already.

### 🚀 New behavior

- The login page appears on the `/login` route.
- A multipage signup form appears on the `/signup` route.

### 🔗 Related to Issue 
- #3 

### 🖼 Preview Link

https://recom-1c662lhs2-vishalpatil18.vercel.app/login

### 💣 Is this a breaking change?
- [ ] Yes
- [x] No

### 🔬 Is the code self-reviewed?
- [x] Yes
- [ ] No

### 📋 Is the code well-formatted?
- [x] Yes
- [ ] No

> NOTE: please do check responsiveness as well. I'm following the mobile-first approach. The CSS Library used is tailwindCSS